### PR TITLE
feat: add reusable version bump actions

### DIFF
--- a/analyze-commits-for-bump/action.yml
+++ b/analyze-commits-for-bump/action.yml
@@ -1,0 +1,111 @@
+name: 'Analyze Commits for Version Bump'
+description: 'Analyzes commits to determine semantic version bump type based on conventional commits'
+
+inputs:
+  from-ref:
+    description: 'Starting reference (tag, SHA, or branch) to analyze from'
+    required: true
+  to-ref:
+    description: 'Ending reference (defaults to HEAD)'
+    required: false
+    default: 'HEAD'
+  max-commits:
+    description: 'Maximum commits to analyze if no from-ref found'
+    required: false
+    default: '10'
+  major-patterns:
+    description: 'Regex patterns for major version bumps (comma-separated)'
+    required: false
+    default: 'BREAKING CHANGE,BREAKING,breaking change,major'
+  minor-patterns:
+    description: 'Regex patterns for minor version bumps (comma-separated)'
+    required: false
+    default: 'feat,feature,minor,add'
+  
+outputs:
+  bump-type:
+    description: 'Determined bump type (major, minor, patch)'
+    value: ${{ steps.analyze.outputs.bump-type }}
+  commit-count:
+    description: 'Number of commits analyzed'
+    value: ${{ steps.analyze.outputs.commit-count }}
+  latest-sha:
+    description: 'Latest commit SHA in the range'
+    value: ${{ steps.analyze.outputs.latest-sha }}
+  has-commits:
+    description: 'Whether any commits were found'
+    value: ${{ steps.analyze.outputs.has-commits }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Analyze commits for bump type
+      id: analyze
+      shell: bash
+      run: |
+        FROM_REF="${{ inputs.from-ref }}"
+        TO_REF="${{ inputs.to-ref }}"
+        MAX_COMMITS="${{ inputs.max-commits }}"
+        MAJOR_PATTERNS="${{ inputs.major-patterns }}"
+        MINOR_PATTERNS="${{ inputs.minor-patterns }}"
+
+        echo "🔍 Analyzing commits from $FROM_REF to $TO_REF"
+
+        # Get commits in range
+        if git rev-parse "$FROM_REF" >/dev/null 2>&1; then
+          echo "📝 Analyzing commits from $FROM_REF to $TO_REF"
+          COMMITS=$(git log --oneline --format="%H %s" ${FROM_REF}..${TO_REF} 2>/dev/null || echo "")
+        else
+          echo "📝 Reference $FROM_REF not found, analyzing last $MAX_COMMITS commits"
+          COMMITS=$(git log --oneline --format="%H %s" --max-count=$MAX_COMMITS $TO_REF 2>/dev/null || echo "")
+        fi
+
+        if [[ -z "$COMMITS" ]]; then
+          echo "⚠️ No commits found to analyze"
+          echo "bump-type=patch" >> $GITHUB_OUTPUT
+          echo "commit-count=0" >> $GITHUB_OUTPUT
+          echo "latest-sha=" >> $GITHUB_OUTPUT
+          echo "has-commits=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        # Count commits
+        COMMIT_COUNT=$(echo "$COMMITS" | wc -l | tr -d ' ')
+        echo "📊 Found $COMMIT_COUNT commits to analyze"
+
+        # Get latest SHA
+        LATEST_SHA=$(echo "$COMMITS" | head -1 | awk '{print $1}')
+        
+        # Analyze commit messages for version bump indicators
+        BUMP_TYPE="patch"  # Default to patch
+
+        echo "🔍 Scanning commit messages..."
+
+        # Convert comma-separated patterns to regex
+        MAJOR_REGEX=$(echo "$MAJOR_PATTERNS" | sed 's/,/|/g')
+        MINOR_REGEX=$(echo "$MINOR_PATTERNS" | sed 's/,/|/g')
+
+        # Check for breaking changes (major)
+        if echo "$COMMITS" | grep -iE "($MAJOR_REGEX)" >/dev/null; then
+          BUMP_TYPE="major"
+          echo "🚨 Found breaking changes → major bump"
+        # Check for features (minor)  
+        elif echo "$COMMITS" | grep -iE "($MINOR_REGEX)" >/dev/null; then
+          BUMP_TYPE="minor"
+          echo "✨ Found new features → minor bump"
+        # Default to patch for fixes, chores, etc.
+        else
+          echo "🔧 Found fixes/improvements → patch bump"
+        fi
+
+        # Set outputs
+        echo "bump-type=$BUMP_TYPE" >> $GITHUB_OUTPUT
+        echo "commit-count=$COMMIT_COUNT" >> $GITHUB_OUTPUT
+        echo "latest-sha=$LATEST_SHA" >> $GITHUB_OUTPUT
+        echo "has-commits=true" >> $GITHUB_OUTPUT
+        
+        # Preview info
+        echo "📋 Summary:"
+        echo "  - Bump type: $BUMP_TYPE"
+        echo "  - Commit count: $COMMIT_COUNT"
+        echo "  - Latest SHA: ${LATEST_SHA:0:8}"

--- a/calculate-semantic-version/action.yml
+++ b/calculate-semantic-version/action.yml
@@ -1,0 +1,158 @@
+name: 'Calculate Semantic Version'
+description: 'Calculates new semantic version based on bump type or specific version'
+
+inputs:
+  current-version:
+    description: 'Current semantic version (with or without v prefix)'
+    required: true
+  bump-type:
+    description: 'Type of version bump (major, minor, patch)'
+    required: false
+  specific-version:
+    description: 'Specific version to set (overrides bump-type)'
+    required: false
+  prerelease:
+    description: 'Prerelease identifier (e.g., beta, rc)'
+    required: false
+  prerelease-number:
+    description: 'Prerelease number'
+    required: false
+
+outputs:
+  new-version:
+    description: 'Calculated new version (without v prefix)'
+    value: ${{ steps.calculate.outputs.new-version }}
+  new-version-with-v:
+    description: 'Calculated new version with v prefix'
+    value: ${{ steps.calculate.outputs.new-version-with-v }}
+  version-changed:
+    description: 'Whether version will change'
+    value: ${{ steps.calculate.outputs.version-changed }}
+  major:
+    description: 'Major version number'
+    value: ${{ steps.parse.outputs.major }}
+  minor:
+    description: 'Minor version number'
+    value: ${{ steps.parse.outputs.minor }}
+  patch:
+    description: 'Patch version number'
+    value: ${{ steps.parse.outputs.patch }}
+  previous-major:
+    description: 'Previous major version number'
+    value: ${{ steps.parse-current.outputs.major }}
+  previous-minor:
+    description: 'Previous minor version number'
+    value: ${{ steps.parse-current.outputs.minor }}
+  previous-patch:
+    description: 'Previous patch version number'
+    value: ${{ steps.parse-current.outputs.patch }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Parse current version
+      id: parse-current
+      shell: bash
+      run: |
+        VERSION="${{ inputs.current-version }}"
+        # Remove 'v' prefix if present
+        VERSION="${VERSION#v}"
+        
+        # Extract major, minor, patch
+        if [[ "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-.*)?$ ]]; then
+          MAJOR="${BASH_REMATCH[1]}"
+          MINOR="${BASH_REMATCH[2]}"
+          PATCH="${BASH_REMATCH[3]}"
+          PRERELEASE="${BASH_REMATCH[4]}"
+        else
+          echo "::error::Invalid semantic version format: $VERSION"
+          exit 1
+        fi
+        
+        echo "major=$MAJOR" >> $GITHUB_OUTPUT
+        echo "minor=$MINOR" >> $GITHUB_OUTPUT
+        echo "patch=$PATCH" >> $GITHUB_OUTPUT
+        echo "prerelease=$PRERELEASE" >> $GITHUB_OUTPUT
+        echo "clean-version=$VERSION" >> $GITHUB_OUTPUT
+
+    - name: Calculate new version
+      id: calculate
+      shell: bash
+      run: |
+        CURRENT="${{ steps.parse-current.outputs.clean-version }}"
+        MAJOR=${{ steps.parse-current.outputs.major }}
+        MINOR=${{ steps.parse-current.outputs.minor }}
+        PATCH=${{ steps.parse-current.outputs.patch }}
+        
+        # Check for specific version override
+        if [[ -n "${{ inputs.specific-version }}" ]]; then
+          NEW_VERSION="${{ inputs.specific-version }}"
+          # Remove 'v' prefix if present
+          NEW_VERSION="${NEW_VERSION#v}"
+          echo "📌 Using specific version: $NEW_VERSION"
+        elif [[ -n "${{ inputs.bump-type }}" ]]; then
+          BUMP_TYPE="${{ inputs.bump-type }}"
+          
+          case "$BUMP_TYPE" in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              echo "🚀 Major version bump"
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              echo "✨ Minor version bump"
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              echo "🔧 Patch version bump"
+              ;;
+            *)
+              echo "⚠️ Unknown bump type: $BUMP_TYPE, defaulting to patch"
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
+          
+          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          
+          # Add prerelease if specified
+          if [[ -n "${{ inputs.prerelease }}" ]]; then
+            PRERELEASE="${{ inputs.prerelease }}"
+            if [[ -n "${{ inputs.prerelease-number }}" ]]; then
+              PRERELEASE="${PRERELEASE}.${{ inputs.prerelease-number }}"
+            fi
+            NEW_VERSION="${NEW_VERSION}-${PRERELEASE}"
+          fi
+        else
+          echo "⚠️ No bump type or specific version provided, keeping current version"
+          NEW_VERSION="$CURRENT"
+        fi
+        
+        # Check if version changed
+        if [[ "$NEW_VERSION" == "$CURRENT" ]]; then
+          echo "ℹ️ Version unchanged: $CURRENT"
+          VERSION_CHANGED="false"
+        else
+          echo "✅ Version will change: $CURRENT → $NEW_VERSION"
+          VERSION_CHANGED="true"
+        fi
+        
+        echo "new-version=$NEW_VERSION" >> $GITHUB_OUTPUT
+        echo "new-version-with-v=v$NEW_VERSION" >> $GITHUB_OUTPUT
+        echo "version-changed=$VERSION_CHANGED" >> $GITHUB_OUTPUT
+
+    - name: Parse new version components
+      id: parse
+      shell: bash
+      run: |
+        VERSION="${{ steps.calculate.outputs.new-version }}"
+        
+        # Extract major, minor, patch from new version
+        if [[ "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-.*)?$ ]]; then
+          echo "major=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
+          echo "minor=${BASH_REMATCH[2]}" >> $GITHUB_OUTPUT
+          echo "patch=${BASH_REMATCH[3]}" >> $GITHUB_OUTPUT
+          echo "prerelease=${BASH_REMATCH[4]}" >> $GITHUB_OUTPUT
+        fi


### PR DESCRIPTION
## Summary
Add two new reusable actions for semantic version management that can be used across repositories.

## New Actions

### 1. `analyze-commits-for-bump`
Analyzes commits between two refs to determine the appropriate semantic version bump type (major/minor/patch) based on conventional commit patterns.

**Features:**
- Configurable patterns for major/minor detection
- Returns bump type, commit count, and latest SHA
- Handles missing refs gracefully with fallback to recent commits

### 2. `calculate-semantic-version`
Calculates a new semantic version based on the current version and desired bump type.

**Features:**
- Supports major/minor/patch bumps
- Allows specific version override
- Optional prerelease support
- Returns parsed version components

## Motivation
These actions extract common version bump logic from repository-specific workflows, making them reusable across all Temporal repositories that use semantic versioning.

## Test Plan
- [ ] Test analyze-commits-for-bump with various commit patterns
- [ ] Test calculate-semantic-version with all bump types
- [ ] Test specific version override
- [ ] Integrate with existing workflows

## Related
- Used in conjunction with existing `generate-changelog` action
- Complements `check-version` for version validation