### PR TITLE
VLN-471: Set explicit permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   test-check-version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- `.github/workflows/test.yml`: Added a workflow-level permissions block granting only contents: read and pull-requests: read so the test jobs can check out the repo and read PR metadata while following least-privilege guidance.